### PR TITLE
Bugfix: Fix macOS runtime issue with pytorch version

### DIFF
--- a/reinvent/runmodes/utils/helpers.py
+++ b/reinvent/runmodes/utils/helpers.py
@@ -25,6 +25,9 @@ attachment_points = AttachmentPoints()
 bond_maker = BondMaker()
 logger = logging.getLogger(__name__)
 
+# Get torch major version
+TORCH_MAJOR = int(torch.__version__.split(".")[0])
+
 
 def disable_gradients(model: ModelAdapter) -> None:
     """Disable gradient tracking for all parameters in a model
@@ -51,13 +54,13 @@ def set_torch_device(args_device: str = None, device: str = None) -> torch.devic
 
     if args_device:  # command line overwrites config file
         # NOTE: this will throw a RuntimeError if the device is not available
-        torch.set_default_device(args_device)
+        torch.set_default_device(args_device) if TORCH_MAJOR > 2 else None
         actual_device = torch.device(args_device)
     elif device:
-        torch.set_default_device(device)
-        actual_device = torch.device(device)
+        torch.set_default_device(device) if TORCH_MAJOR > 2 else None
+        actual_device = torch.device(device) 
     else:  # we assume there are no other devices...
-        torch.set_default_device("cpu")
+        torch.set_default_device("cpu") if TORCH_MAJOR > 2 else None
         actual_device = torch.device("cpu")
 
     logger.debug(f"{actual_device=}")


### PR DESCRIPTION
**Description:**
The `requirements-linux-64.lock` file specifies PyTorch version > 2, whereas the `requirements-macOS.lock` file specifies PyTorch version 1. This discrepancy causes the helper function to break when attempting to call `torch.set_default_device`, which is only available in PyTorch > 2. The function call has been updated to be conditional on the PyTorch version, ensuring compatibility across different platforms.

**Changes:**
- Modified the helper function to conditionally call `torch.set_default_device` only if the PyTorch version is greater than 2.

**Testing:**
- Tested locally on a Mac by running `reinvent -l sampling.log sampling.toml` with the device set to CPU rather than CUDA.
- Verified that the code runs without errors on macOS with PyTorch version 1.
