### PR TITLE
PMI component bugfix: properly catch invalid mols

### DIFF
--- a/reinvent_plugins/components/RDKit/comp_pmi.py
+++ b/reinvent_plugins/components/RDKit/comp_pmi.py
@@ -40,7 +40,9 @@ class PMI:
         for mol in mols:
             try:
                 mol3d = Chem.AddHs(mol)
-                Chem.EmbedMolecule(mol3d)
+                embed_result = Chem.EmbedMolecule(mol3d)
+                if embed_result == -1:  # embedding failed
+                    raise ValueError("Embedding failed")
 
                 npr1 = Chem.CalcNPR1(mol3d)
                 npr2 = Chem.CalcNPR2(mol3d)

--- a/reinvent_plugins/components/RDKit/comp_pmi.py
+++ b/reinvent_plugins/components/RDKit/comp_pmi.py
@@ -38,17 +38,15 @@ class PMI:
         scores2 = []
 
         for mol in mols:
-            try:
-                mol3d = Chem.AddHs(mol)
-                embed_result = Chem.EmbedMolecule(mol3d)
-                if embed_result == -1:  # embedding failed
-                    raise ValueError("Embedding failed")
-
-                npr1 = Chem.CalcNPR1(mol3d)
-                npr2 = Chem.CalcNPR2(mol3d)
-            except ValueError:
+            mol3d = Chem.AddHs(mol)
+            embed_result = Chem.EmbedMolecule(mol3d)
+            
+            if embed_result == -1:  # embedding failed
                 npr1 = np.nan
                 npr2 = np.nan
+            else:
+                npr1 = Chem.CalcNPR1(mol3d)
+                npr2 = Chem.CalcNPR2(mol3d)
 
             scores1.append(npr1)
             scores2.append(npr2)


### PR DESCRIPTION
PMI component was giving me this error:

Traceback (most recent call last):
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/bin/reinvent", line 8, in <module>
    sys.exit(main())
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/lib/python3.10/site-packages/reinvent/Reinvent.py", line 334, in main
    runner(
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/lib/python3.10/site-packages/reinvent/runmodes/RL/run_staged_learning.py", line 367, in run_staged_learning
    terminate = optimize(package.terminator)
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/lib/python3.10/site-packages/reinvent/runmodes/RL/learning.py", line 118, in optimize
    results = self.score()
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/lib/python3.10/site-packages/reinvent/runmodes/RL/learning.py", line 192, in score
    results = self.scoring_function(
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/lib/python3.10/site-packages/reinvent/scoring/scorer.py", line 138, in compute_results
    transform_result = compute_transform(
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/lib/python3.10/site-packages/reinvent/scoring/compute_scores.py", line 101, in compute_transform
    component_results = compute_component_scores(
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/lib/python3.10/site-packages/reinvent/scoring/compute_scores.py", line 62, in compute_component_scores
    component_results = scoring_function(smilies_non_cached)
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/lib/python3.10/site-packages/reinvent_plugins/mol_cache.py", line 35, in wrapper
    return func(self, mols)
  File "/ceph/hpc/home/deklevad/miniforge3/envs/reinvent4/lib/python3.10/site-packages/reinvent_plugins/components/RDKit/comp_pmi.py", line 45, in __call__
    npr1 = Chem.CalcNPR1(mol3d)
RuntimeError: Pre-condition Violation
	molecule has no conformers
	Violation occurred on line 112 in file Code/GraphMol/Descriptors/PMI.cpp
	Failed Expression: mol.getNumConformers() >= 1
	RDKIT: 2023.09.5
	BOOST: 1_78

I noticed it wasn't properly catching invalid molecules that can't be embedded. I added a condition that if the embedding process returns -1 (which means it failed - according to rdkit docs), it raises ValueError and proceeds gracefully.