### PR TITLE
feat: make reinvent an executable module

### DIFF
--- a/reinvent/__main__.py
+++ b/reinvent/__main__.py
@@ -1,0 +1,3 @@
+from .Reinvent import main
+
+main()


### PR DESCRIPTION
Make it possible to execute `reinvent` as an [executable module](https://docs.python.org/3/library/__main__.html#main-py-in-python-packages):

```shell
python -m reinvent --help
```

This uses the same function used by the `reinvent` script defined in `pyproject.toml`; calling `python -m reinvent` is identical to using the `reinvent` command.

This will make it easy to configure the VSCode debugger to launch `reinvent` in debug mode. Add this to the `.vscode/launch.json`:

```json
{
    "name": "Reinvent",
    "type": "debugpy",
    "request": "launch",
    "module": "reinvent",
    "console": "integratedTerminal",
    "args": [
        "sampling.toml"
    ]
}
```