### PR TITLE
fix normalize call in sampler

### DIFF
--- a/reinvent/runmodes/samplers/run_sampling.py
+++ b/reinvent/runmodes/samplers/run_sampling.py
@@ -93,7 +93,7 @@ def run_sampling(
 
     # FIXME: remove atom map numbers from SMILES in chemistry code
     if model_type == "Libinvent":
-        sampled.smilies = normalize(sampled.smilies, keep_all=True)
+        sampled.smilies = normalize(sampled.smilies)
 
     kwargs = {}
     scores = [-1] * len(sampled.items2)


### PR DESCRIPTION
The example sampling.toml file with libinvent fails to run. This is because of a bug in the `normalize()` call in run_sampling.py at line 96. This PR fixes this issue #162 