### PR TITLE
Modified SMILES regex in data pipeline to disallow three-digit ring numbers.

### DIFF
--- a/reinvent/datapipeline/filters/chem.py
+++ b/reinvent/datapipeline/filters/chem.py
@@ -128,33 +128,6 @@ class RDKitFilter:
             else:
                 raise
 
-        # FIXME: an atom may have 3 ring numbers or more e.g.
-        #        C%108%11 which is %10 8 %11 and should become 8%11 %10
-        #        for the tokenizer or be caught in a single regex maybe like
-        #        "\d*(?:%\d+){1,}"
         #        clean up unwanted halogens here!
-        if "%" in new_smiles:
-            smiles_patterns = SMILES_TOKENS_REGEX.findall(new_smiles)
-            patterns = []
-
-            for pattern in smiles_patterns:
-                # This needs to be done here because RDKit may change
-                # ring numbering
-                # Handles labels in the form %NNN or %NNNN
-                if pattern[0] == "%":
-                    # FIXME: safeguard against multi ring labels for now
-                    if int(pattern[1:]) > config.max_num_rings:
-                        return None
-
-                    elem_len = len(pattern[1:])
-
-                    if elem_len == 3:
-                        pattern = f"{pattern[3:]}%{pattern[1:3]}"
-                    elif elem_len == 4:
-                        pattern = f"%{pattern[1:3]}%{pattern[3:]}"
-
-                patterns.append(pattern)
-
-            new_smiles = "".join(patterns)
 
         return new_smiles

--- a/reinvent/datapipeline/filters/regex.py
+++ b/reinvent/datapipeline/filters/regex.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 # adapted from SmilesPE-0.0.3
 SMILES_TOKENS_REGEX = re.compile(
-    r"(\[[^]]+]|Br?|Cl?|N|O|S|P|F|I|b|c|n|o|s|p|\(|\)|\.|=|#|-|\+|\\|/|:|~|@|\?|>>?|\*|\$|%\d+|\d)"
+    r"(\[[^]]+]|Br?|Cl?|N|O|S|P|F|I|b|c|n|o|s|p|\(|\)|\.|=|#|-|\+|\\|/|:|~|@|\?|>>?|\*|\$|%\d{2}|\d)"
 )
 ELEMENT = re.compile(r"[A-Za-z]+")
 ISOTOPE = re.compile(r"\[\d+")


### PR DESCRIPTION
This PR removes the ring number reordering in the data pipeline. The ring reordering may render SMILES strings unreadable by RDKit in exceptional cases; see #183. This PR additionally solves that.

To circumvent issues in tokenization, the regex used to parse ring numbers is instead changed from “%\d+” to “%\d{2}”, catching only two-digit numbers following percentage signs. This renders the reordering unnecessary.

Three-digit ring numbers are disallowed under the OpenSMILES standard and would only appear for cases where 100 ring closures are open simultaneously, which should be exceedingly rare.