### PR TITLE
Fix seed behavior

### DIFF
--- a/reinvent/Reinvent.py
+++ b/reinvent/Reinvent.py
@@ -132,11 +132,9 @@ def main(args: Any):
     else:
         logger.info(f"Using CPU {platform.processor()}")
 
-    seed = input_config.get("seed", None)
-
     if args.seed is not None:
-        set_seed(seed)
-        logger.info(f"Set seed for all random generators to {seed}")
+        set_seed(args.seed)
+        logger.info(f"Set seed for all random generators to {args.seed}")
 
     tb_logdir = input_config.get("tb_logdir", None)
 


### PR DESCRIPTION
User supplied seed is stored in args.seed; reading seed from config file always returns None resulting in non-deterministic behavior.