### PR TITLE
Implement random seed behavior

### DIFF
--- a/configs/json/sampling.json
+++ b/configs/json/sampling.json
@@ -3,7 +3,7 @@
     "use_cuda": true,
     "json_out_config": "_sampling.json",
     "parameters": {
-        "model_file": "models/reinvent.prior",
+        "model_file": "priors/reinvent.prior",
         "output_file": "sampling.csv",
         "num_smiles": 157,
         "unique_molecules": true,

--- a/configs/json/sampling.json
+++ b/configs/json/sampling.json
@@ -3,7 +3,7 @@
     "use_cuda": true,
     "json_out_config": "_sampling.json",
     "parameters": {
-        "model_file": "priors/reinvent.prior",
+        "model_file": "models/reinvent.prior",
         "output_file": "sampling.csv",
         "num_smiles": 157,
         "unique_molecules": true,

--- a/configs/toml/PARAMS.md
+++ b/configs/toml/PARAMS.md
@@ -12,6 +12,7 @@ Sample a number of SMILES with associated NLLs.
 | run\_type          | set to "sampling"                                                                                    |
 | device             | set the torch device e.g "cuda:0" or "cpu"                                                           |
 | use\_cuda          | (deprecated) "true" to use GPU, "false" to use CPU                                                   |
+| seed               | sets the random seeds for reproducibility               |
 | json\_out\_config    | filename of the TOML file in JSON format                                                             |
 | [parameters]       | starts the parameter section                                                                         |
 | model\_file        | filename to model file from which to sample                                                          |
@@ -35,6 +36,7 @@ Interface to the scoring component.  Does not use any models.
 | run\_type           | set to "scoring"                                                                                        |
 | device              | set the torch device e.g "cuda:0" or "cpu"                                                              |
 | use\_cuda           | (deprecated) "true" to use GPU, "false" to use CPU                                                      |
+| seed               | sets the random seeds for reproducibility (no effect in scoring mode)               |
 | json\_out\_config   | filename of the TOML file in JSON format                                                                |
 | [parameters]        | starts the parameter section                                                                            |
 | smiles\_file        | SMILES filename, SMILES are expected in the first column                                                |
@@ -56,6 +58,7 @@ Run transfer learning on a set of input SMILES.
 | run\_type              | set to "transfer\_learning"                                    |
 | device             | set the torch device e.g "cuda:0" or "cpu"                                                             |
 | use\_cuda          | (deprecated) "true" to use GPU, "false" to use CPU                                                     |
+| seed               | sets the random seeds for reproducibility               |
 | json\_out\_config        | filename of the TOML file in JSON format                      |
 | tb\_logdir             | if not empty string name of the TensorBoard logging directory |
 | number\_of\_cpus       | optional parameter to control number of cpus for pair  generation. If not provided, only one CPU will be used. |
@@ -84,6 +87,7 @@ Run reinforcement learning (RL) and/or curriculum learning (CL).  CL is simply a
 | run\_type            | set to "staged\_learning"                                                                                                    |
 | device               | set the torch device e.g "cuda:0" or "cpu"                                                                                     |
 | use\_cuda            | (deprecated) "true" to use GPU, "false" to use CPU                                                                             |
+| seed                 | sets the random seeds for reproducibility               |
 | json\_out\_config    | filename of the TOML file in JSON format                                                                                       |
 | tb\_logdir           | if not empty string name of the TensorBoard logging directory                                                                  |
 | [parameters]         | starts the parameter section                                                                                                   |

--- a/configs/toml/sampling.toml
+++ b/configs/toml/sampling.toml
@@ -5,7 +5,6 @@
 run_type = "sampling"
 device = "cuda:0"  # set torch device e.g. "cpu"
 json_out_config = "_sampling.json"  # write this TOML to JSON
-#seed = 42  # set the random seeds for reproducibility
 
 [parameters]
 

--- a/configs/toml/sampling.toml
+++ b/configs/toml/sampling.toml
@@ -5,7 +5,7 @@
 run_type = "sampling"
 device = "cuda:0"  # set torch device e.g. "cpu"
 json_out_config = "_sampling.json"  # write this TOML to JSON
-
+#seed = 42  # set the random seeds for reproducibility
 
 [parameters]
 

--- a/configs/toml/staged_learning.toml
+++ b/configs/toml/staged_learning.toml
@@ -12,7 +12,6 @@ run_type = "staged_learning"
 device = "cuda:0"  # set torch device e.g. "cpu"
 tb_logdir = "tb_logs"  # name of the TensorBoard logging directory
 json_out_config = "_staged_learning.json"  # write this TOML to JSON
-#seed = 42  # set the random seeds for reproducibility
 
 [parameters]
 

--- a/configs/toml/staged_learning.toml
+++ b/configs/toml/staged_learning.toml
@@ -12,6 +12,7 @@ run_type = "staged_learning"
 device = "cuda:0"  # set torch device e.g. "cpu"
 tb_logdir = "tb_logs"  # name of the TensorBoard logging directory
 json_out_config = "_staged_learning.json"  # write this TOML to JSON
+#seed = 42  # set the random seeds for reproducibility
 
 [parameters]
 

--- a/configs/toml/transfer_learning.toml
+++ b/configs/toml/transfer_learning.toml
@@ -8,7 +8,7 @@ run_type = "transfer_learning"
 device = "cuda:0"  # set torch device e.g. "cpu"
 tb_logdir = "tb_TL"  # name of the TensorBoard logging directory
 json_out_config = "json_transfer_learning.json"  # write this TOML to JSON
-
+#seed = 42  # set the random seeds for reproducibility
 
 [parameters]
 

--- a/configs/toml/transfer_learning.toml
+++ b/configs/toml/transfer_learning.toml
@@ -8,7 +8,6 @@ run_type = "transfer_learning"
 device = "cuda:0"  # set torch device e.g. "cpu"
 tb_logdir = "tb_TL"  # name of the TensorBoard logging directory
 json_out_config = "json_transfer_learning.json"  # write this TOML to JSON
-#seed = 42  # set the random seeds for reproducibility
 
 [parameters]
 

--- a/reinvent/Reinvent.py
+++ b/reinvent/Reinvent.py
@@ -132,14 +132,11 @@ def main(args: Any):
     else:
         logger.info(f"Using CPU {platform.processor()}")
 
-    seed = input_config.get("seed", None)
+    seed = args.seed or input_config.get("seed", None)
 
-    if args.seed is None:
+    if seed is not None:
         set_seed(seed)
         logger.info(f"Set seed for all random generators to {seed}")
-    else:
-        set_seed(args.seed)
-        logger.info(f"Set seed for all random generators to {args.seed}")
 
     tb_logdir = input_config.get("tb_logdir", None)
 

--- a/reinvent/Reinvent.py
+++ b/reinvent/Reinvent.py
@@ -134,9 +134,12 @@ def main(args: Any):
 
     seed = input_config.get("seed", None)
 
-    if args.seed is not None:
+    if args.seed is None:
         set_seed(seed)
         logger.info(f"Set seed for all random generators to {seed}")
+    else:
+        set_seed(args.seed)
+        logger.info(f"Set seed for all random generators to {args.seed}")
 
     tb_logdir = input_config.get("tb_logdir", None)
 

--- a/reinvent/utils/cli.py
+++ b/reinvent/utils/cli.py
@@ -79,7 +79,7 @@ def parse_command_line():
         metavar="N",
         type=int,
         default=None,
-        help="Sets the random seeds for reproducibility",
+        help=f"Sets the random seeds for reproducibility. {OVERWRITE_STR}.",
     )
 
     parser.add_argument(

--- a/reinvent/validation.py
+++ b/reinvent/validation.py
@@ -15,6 +15,7 @@ class ReinventConfig(GlobalConfig):
     use_cuda: Optional[bool] = Field(True, deprecated="use 'device' instead")
     tb_logdir: Optional[str] = None
     json_out_config: Optional[str] = None
+    seed: Optional[int] = None
     parameters: dict
 
     # run mode dependent


### PR DESCRIPTION
Fix nondeterministic seed behavior originally mentioned in #203. 
Implemented random seed behavior according to [spec](https://github.com/MolecularAI/REINVENT4/pull/203#issuecomment-2647412426).
Random seed can now be supplied by the user via CLI or config file. Seed from CLI has priority.