### PR TITLE
Fixed libinvent example SMILES attachment point numbering

### DIFF
--- a/configs/scaffolds.smi
+++ b/configs/scaffolds.smi
@@ -3,6 +3,6 @@
 # One scaffold per line
 # Each scaffold must be annotated by 2 '*'s to locate the attachment points
 
-[*:1]Cc2ccc1cncc(C[*:2])c1c2
-[*:1]Cc2cnc1cncc(C[*:2])c1c2
+[*:0]Cc2ccc1cncc(C[*:1])c1c2
+[*:0]Cc2cnc1cncc(C[*:1])c1c2
 


### PR DESCRIPTION
Fixed the Libinvent example to start attachment point numbering from 0 instead of 1