### PR TITLE
New sampling strategy for mini-batch diversification

### DIFF
--- a/reinvent/runmodes/RL/intrinsic_penalty/identical_murcko_scaffold_rnd.py
+++ b/reinvent/runmodes/RL/intrinsic_penalty/identical_murcko_scaffold_rnd.py
@@ -75,7 +75,7 @@ class IdenticalMurckoScaffoldRND(IntrinsicPenalty):
         smilies: List[str],
         mask: np.ndarray,
         sampled: SampleBatch,
-    ) -> List:
+    ) -> Tuple[List, np.ndarray]:
         """Compute the score and add intrinsic rewards based on RND."""
 
         assert len(smilies) == len(
@@ -89,9 +89,13 @@ class IdenticalMurckoScaffoldRND(IntrinsicPenalty):
             topological=False,
         )
 
+        # Copy total_scores to save the penalized scores before adding intrinsic rewards
+        # This is returned for back-compatible reporting of scores.
+        penalized_scores = scores.copy()
+
         self._add_intrinsic_reward(sampled, scores, active_idxs)
 
-        return scaffolds
+        return scaffolds, penalized_scores
 
     def _calculate_novelty_reinvent(
         self, sampled: SampleBatch, scores: np.ndarray, active_idxs: List[int]

--- a/reinvent/runmodes/RL/intrinsic_penalty/intrinsic_penalty.py
+++ b/reinvent/runmodes/RL/intrinsic_penalty/intrinsic_penalty.py
@@ -66,14 +66,14 @@ class IntrinsicPenalty(ABC):
     @abstractmethod
     def update_score(
         self, scores: np.ndarray, smilies: List[str], mask: np.ndarray, sampled: SampleBatch
-    ) -> List:
+    ) -> Tuple[List, np.ndarray]:
         """Update the score according to the concrete fitler.
 
         :param scores: an array with precomputed scores
         :param smilies: list of SMILES
         :param mask: mask for valid SMILES
         :param sampled: batch of sampled SMILES
-        :return: array with the updated scores and scaffolds where available
+        :return: in-place updated scores, scaffolds where available and penalized scores
         """
 
     def score_scaffolds(

--- a/reinvent/runmodes/RL/learning.py
+++ b/reinvent/runmodes/RL/learning.py
@@ -143,10 +143,11 @@ class Learning(ABC):
                 scaffolds = self._state.diversity_filter.update_score(
                     results.total_scores, results.smilies, df_mask
                 )
+
             elif self.intrinsic_penalty:
                 df_mask = np.where(self.invalid_mask, True, False)
 
-                scaffolds = self.intrinsic_penalty.update_score(
+                scaffolds, penalized_scores = self.intrinsic_penalty.update_score(
                     results.total_scores, results.smilies, df_mask, self.sampled
                 )
 
@@ -156,6 +157,11 @@ class Learning(ABC):
 
             state_dict = self._state.as_dict()
             self._state_info.update(state_dict)
+
+            if not self._state.diversity_filter and self.intrinsic_penalty:
+                # Remove the intrinsic penalty scores from the results for reporting
+                # This is done after using intrinsic scores for the update
+                results.total_scores = penalized_scores
 
             nan_idx = np.isnan(results.total_scores)
             scores = results.total_scores[~nan_idx]


### PR DESCRIPTION
This PR integrates the improvement suggested by the paper [Diverse Mini-Batch Selection in Reinforcement Learning for Efficient Chemical Exploration in de novo Drug Design](https://arxiv.org/abs/2506.21158). It provides a sampling strategy dpp that enhances the chemical diversity of multinomial sampling. The paper focuses on the Reinvent model, but the strategy is model-agnostic and, therefore, I have also implemented this sample strategy for the other models (except Pepinvent). It can be implemented for Pepinvent, but then we need to select an appropriate similarity function between peptides.

## Key Changes
### Core implementation:

- Adds a sampling strategy dpp for the Reinvent, Linkinvent, Libinvent and Mol2mol samplers.
- No changes of the model-specific sampling, the PR uses the models' multinomial sampling with oversampling to select a diverse mini-batch.
- Allows specifying sample_strategy in TOML config file for all models. If no sample strategy is given, None is still the default for non-Transformer models for backward compatibility.

### Testing:

- Add sampling tests (integration tests) for the dpp-based samplers of reinvent, linkinvent, libinvent and mol2mol.

All tests pass.