### PR TITLE
Early stopping based on unique generated SMILES

### DIFF
--- a/reinvent/runmodes/RL/data_classes/work_package.py
+++ b/reinvent/runmodes/RL/data_classes/work_package.py
@@ -22,6 +22,7 @@ class WorkPackage:
     scoring_function: Scorer
     learning_strategy: RLReward
     max_steps: int
+    max_smiles: int
     terminator: Callable
     diversity_filter: DiversityFilter = None
     out_state_filename: str = None

--- a/reinvent/runmodes/RL/learning.py
+++ b/reinvent/runmodes/RL/learning.py
@@ -133,7 +133,12 @@ class Learning(ABC):
 
         for step in range(self.max_steps):
             self.sampled = self.sampling_model.sample(self.input_smilies)
-            self.smiles_memory.update(self.sampled.smilies)  # NOTE: global -> only update here!
+            # Add only valid non-duplicate SMILES to memory
+            memory_update = [
+                smi for smi, sta in zip(self.sampled.smilies, self.sampled.states)
+                if sta == SmilesState.VALID
+            ]
+            self.smiles_memory.update(memory_update)  # NOTE: global -> only update here!
 
             self.invalid_mask = np.where(self.sampled.states == SmilesState.INVALID, False, True)
             self.duplicate_mask = np.where(

--- a/reinvent/runmodes/RL/learning.py
+++ b/reinvent/runmodes/RL/learning.py
@@ -49,6 +49,7 @@ class Learning(ABC):
     def __init__(
         self,
         max_steps: int,
+        max_smiles: int,
         stage_no: int,
         prior: ModelAdapter,
         state: ModelState,
@@ -67,6 +68,7 @@ class Learning(ABC):
         """Setup of the common framework"""
 
         self.max_steps = max_steps
+        self.max_smiles = max_smiles
         self.stage_no = stage_no
         self.prior = prior
 
@@ -180,6 +182,10 @@ class Learning(ABC):
                 augmented_nll=augmented_nll,
                 loss=float(loss),
             )
+
+            if len(self.smiles_memory) > self.max_smiles:
+                logger.info(f"Max SMILES reached, terminating in {step = }")
+                break
 
             if converged(mean_scores, step):
                 logger.info(f"Terminating early in {step = }")

--- a/reinvent/runmodes/RL/learning.py
+++ b/reinvent/runmodes/RL/learning.py
@@ -189,7 +189,7 @@ class Learning(ABC):
             )
 
             if len(self.smiles_memory) > self.max_smiles:
-                logger.info(f"Max SMILES reached, terminating in {step = }")
+                logger.info(f"Max SMILES ({self.max_smiles}) reached, terminating in {step = }")
                 break
 
             if converged(mean_scores, step):

--- a/reinvent/runmodes/RL/run_staged_learning.py
+++ b/reinvent/runmodes/RL/run_staged_learning.py
@@ -170,6 +170,7 @@ def run_staged_learning(
 
             optimize = model_learning(
                 max_steps=package.max_steps,
+                max_smiles=package.max_smiles,
                 stage_no=stage_no,
                 prior=prior,
                 state=state,

--- a/reinvent/runmodes/RL/setup/create_packages.py
+++ b/reinvent/runmodes/RL/setup/create_packages.py
@@ -38,6 +38,8 @@ def create_packages(
         max_score = stage.max_score
         min_steps = stage.min_steps
         max_steps = stage.max_steps
+        patience = stage.patience
+        topk = stage.topk
         max_smiles = stage.max_smiles
 
         terminator_param = stage.termination
@@ -45,6 +47,12 @@ def create_packages(
 
         try:
             terminator: terminator_callable = getattr(terminators, f"{terminator_name}Terminator")
+            # Uses mean scores
+            if terminator_name in ["Simple", "Plateau"]:
+                terminator = terminator(max_score, min_steps)
+            # Uses batch scores
+            elif terminator_name == "Topk":
+                terminator = terminator(patience, min_steps, topk)
         except KeyError:
             msg = f"Unknown termination criterion: {terminator_name}"
             logger.critical(msg)
@@ -61,7 +69,7 @@ def create_packages(
                 reward_strategy,
                 max_steps,
                 max_smiles,
-                terminator(max_score, min_steps),
+                terminator,
                 diversity_filter,
                 chkpt_filename,
             )

--- a/reinvent/runmodes/RL/setup/create_packages.py
+++ b/reinvent/runmodes/RL/setup/create_packages.py
@@ -38,6 +38,7 @@ def create_packages(
         max_score = stage.max_score
         min_steps = stage.min_steps
         max_steps = stage.max_steps
+        max_smiles = stage.max_smiles
 
         terminator_param = stage.termination
         terminator_name = terminator_param.lower().title()
@@ -59,6 +60,7 @@ def create_packages(
                 scoring_function,
                 reward_strategy,
                 max_steps,
+                max_smiles,
                 terminator(max_score, min_steps),
                 diversity_filter,
                 chkpt_filename,

--- a/reinvent/runmodes/RL/validation.py
+++ b/reinvent/runmodes/RL/validation.py
@@ -59,6 +59,8 @@ class SectionStage(GlobalConfig):
     max_steps: int = Field(ge=1)
     max_score: Optional[float] = Field(1.0, ge=0.0, le=1.0)
     max_smiles: int = Field(100000000, ge=0) # arbitrary maximum
+    topk: Optional[int] = Field(10, ge=1)
+    patience: Optional[int] = Field(100, ge=1)
     chkpt_file: Optional[str] = None
     termination: str = "simple"
     min_steps: Optional[int] = Field(50, ge=0)

--- a/reinvent/runmodes/RL/validation.py
+++ b/reinvent/runmodes/RL/validation.py
@@ -58,6 +58,7 @@ class SectionInception(GlobalConfig):
 class SectionStage(GlobalConfig):
     max_steps: int = Field(ge=1)
     max_score: Optional[float] = Field(1.0, ge=0.0, le=1.0)
+    max_smiles: int = Field(100000000, ge=0) # arbitrary maximum
     chkpt_file: Optional[str] = None
     termination: str = "simple"
     min_steps: Optional[int] = Field(50, ge=0)


### PR DESCRIPTION
This PR adds a new stage parameter (`max_smiles`) that stops generation once the number of canonicalized generated SMILES reaches `max_smiles`. This also changes the behaviour of `learning.py` to add only valid SMILES to `smiles_memory`.

This allows for the running of the Practical Molecular Optimization benchmark through REINVENT4 by setting `max_smiles` to 10000.